### PR TITLE
feat: add mongo persistence for playlists and tags

### DIFF
--- a/j9/api.ts
+++ b/j9/api.ts
@@ -1,0 +1,69 @@
+const API_BASE = 'http://localhost:3001/api';
+
+export async function fetchPlaylists(): Promise<Record<string, string[]>> {
+  const res = await fetch(`${API_BASE}/playlists`);
+  if (!res.ok) throw new Error('Failed to fetch playlists');
+  return res.json();
+}
+
+export async function createPlaylist(name: string) {
+  await fetch(`${API_BASE}/playlists`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+}
+
+export async function renamePlaylist(oldName: string, newName: string) {
+  await fetch(`${API_BASE}/playlists/${encodeURIComponent(oldName)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ newName })
+  });
+}
+
+export async function deletePlaylist(name: string) {
+  await fetch(`${API_BASE}/playlists/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+export async function addShotToPlaylist(name: string, shotId: string) {
+  await fetch(`${API_BASE}/playlists/${encodeURIComponent(name)}/shots`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ shotId })
+  });
+}
+
+export async function removeShotFromPlaylist(name: string, shotId: string) {
+  await fetch(`${API_BASE}/playlists/${encodeURIComponent(name)}/shots/${encodeURIComponent(shotId)}`, {
+    method: 'DELETE'
+  });
+}
+
+export async function fetchTags(): Promise<Record<string, string[]>> {
+  const res = await fetch(`${API_BASE}/tags`);
+  if (!res.ok) throw new Error('Failed to fetch tags');
+  return res.json();
+}
+
+export async function addTag(shotId: string, tag: string) {
+  await fetch(`${API_BASE}/tags/${encodeURIComponent(shotId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tag })
+  });
+}
+
+export async function removeTag(shotId: string, tag: string) {
+  await fetch(`${API_BASE}/tags/${encodeURIComponent(shotId)}/${encodeURIComponent(tag)}`, {
+    method: 'DELETE'
+  });
+}
+
+export async function renameTag(oldTag: string, newTag: string) {
+  await fetch(`${API_BASE}/tags/rename`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ oldTag, newTag })
+  });
+}

--- a/server/index.js
+++ b/server/index.js
@@ -13,19 +13,111 @@ mongoose.connect('mongodb+srv://rtsharebox:JVDD5dELVrah8wY9@cluster0.jqrnlot.mon
   useUnifiedTopology: true,
 });
 
-// مدل نمونه
-const Item = mongoose.model('Item', { name: String });
+// Tag model
+const tagSchema = new mongoose.Schema({
+  shotId: { type: String, required: true },
+  value: { type: String, required: true }
+});
+const Tag = mongoose.model('Tag', tagSchema);
 
-// مسیرها
-app.get('/api/items', async (req, res) => {
-  const items = await Item.find();
-  res.json(items);
+// Playlist model
+const playlistSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  shotIds: { type: [String], default: [] }
+});
+const Playlist = mongoose.model('Playlist', playlistSchema);
+
+// Tag routes
+app.get('/api/tags', async (req, res) => {
+  const tags = await Tag.find();
+  const result = {};
+  tags.forEach(t => {
+    if (!result[t.shotId]) result[t.shotId] = [];
+    result[t.shotId].push(t.value);
+  });
+  res.json(result);
 });
 
-app.post('/api/items', async (req, res) => {
-  const newItem = new Item({ name: req.body.name });
-  await newItem.save();
-  res.json(newItem);
+app.post('/api/tags/:shotId', async (req, res) => {
+  const { shotId } = req.params;
+  const { tag } = req.body;
+  if (!tag) return res.status(400).json({ error: 'Tag required' });
+  await new Tag({ shotId, value: tag }).save();
+  const tags = await Tag.find({ shotId });
+  res.json(tags.map(t => t.value));
+});
+
+app.delete('/api/tags/:shotId/:tag', async (req, res) => {
+  const { shotId, tag } = req.params;
+  await Tag.deleteOne({ shotId, value: tag });
+  const tags = await Tag.find({ shotId });
+  res.json(tags.map(t => t.value));
+});
+
+app.put('/api/tags/rename', async (req, res) => {
+  const { oldTag, newTag } = req.body;
+  if (!oldTag || !newTag) return res.status(400).json({ error: 'Tags required' });
+  await Tag.updateMany({ value: oldTag }, { $set: { value: newTag } });
+  res.json({ success: true });
+});
+
+// Playlist routes
+app.get('/api/playlists', async (req, res) => {
+  const lists = await Playlist.find();
+  const result = {};
+  lists.forEach(p => {
+    result[p.name] = p.shotIds;
+  });
+  res.json(result);
+});
+
+app.post('/api/playlists', async (req, res) => {
+  const { name } = req.body;
+  if (!name) return res.status(400).json({ error: 'Name required' });
+  const playlist = new Playlist({ name });
+  await playlist.save();
+  res.json(playlist);
+});
+
+app.put('/api/playlists/:name', async (req, res) => {
+  const { name } = req.params;
+  const { newName } = req.body;
+  const playlist = await Playlist.findOneAndUpdate(
+    { name },
+    { $set: { name: newName } },
+    { new: true }
+  );
+  if (!playlist) return res.status(404).json({ error: 'Playlist not found' });
+  res.json(playlist);
+});
+
+app.delete('/api/playlists/:name', async (req, res) => {
+  const { name } = req.params;
+  await Playlist.deleteOne({ name });
+  res.json({ success: true });
+});
+
+app.post('/api/playlists/:name/shots', async (req, res) => {
+  const { name } = req.params;
+  const { shotId } = req.body;
+  const playlist = await Playlist.findOneAndUpdate(
+    { name },
+    { $addToSet: { shotIds: shotId } },
+    { new: true }
+  );
+  if (!playlist) return res.status(404).json({ error: 'Playlist not found' });
+  res.json(playlist);
+});
+
+app.delete('/api/playlists/:name/shots/:shotId', async (req, res) => {
+  const { name, shotId } = req.params;
+  const playlist = await Playlist.findOneAndUpdate(
+    { name },
+    { $pull: { shotIds: shotId } },
+    { new: true }
+  );
+  if (!playlist) return res.status(404).json({ error: 'Playlist not found' });
+  res.json(playlist);
 });
 
 const PORT = 3001;


### PR DESCRIPTION
## Summary
- add Mongoose models and REST endpoints for tags and playlists
- expose frontend API helpers for MongoDB persistence
- wire playlist and tag operations in React app to use new APIs

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f35d1c7d883268ac63eec80f48342