### PR TITLE
Add Directory entity and persist selected folders

### DIFF
--- a/j9/App.tsx
+++ b/j9/App.tsx
@@ -14,7 +14,8 @@ import {
   removeShotFromPlaylist,
   addTag as apiAddTag,
   removeTag as apiRemoveTag,
-  renameTag as apiRenameTag
+  renameTag as apiRenameTag,
+  saveDirectory
 } from './api';
 
 // Augment React's HTMLAttributes to include non-standard directory attributes
@@ -120,6 +121,14 @@ const App: React.FC = () => {
   const handleFilesSelected = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (!files || files.length === 0) return;
+    const rootDir = (files[0] as any).webkitRelativePath?.split('/')[0];
+    if (rootDir) {
+      try {
+        await saveDirectory(rootDir);
+      } catch (err) {
+        console.error('Failed to save directory', err);
+      }
+    }
 
     setIsLoading(true);
     setError(null);

--- a/j9/api.ts
+++ b/j9/api.ts
@@ -67,3 +67,17 @@ export async function renameTag(oldTag: string, newTag: string) {
     body: JSON.stringify({ oldTag, newTag })
   });
 }
+
+export async function fetchDirectories(): Promise<string[]> {
+  const res = await fetch(`${API_BASE}/directories`);
+  if (!res.ok) throw new Error('Failed to fetch directories');
+  return res.json();
+}
+
+export async function saveDirectory(path: string) {
+  await fetch(`${API_BASE}/directories`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path })
+  });
+}

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,12 @@ const playlistSchema = new mongoose.Schema({
 });
 const Playlist = mongoose.model('Playlist', playlistSchema);
 
+// Directory model
+const directorySchema = new mongoose.Schema({
+  path: { type: String, required: true, unique: true }
+});
+const Directory = mongoose.model('Directory', directorySchema);
+
 // Tag routes
 app.get('/api/tags', async (req, res) => {
   const tags = await Tag.find();
@@ -116,6 +122,25 @@ app.delete('/api/playlists/:name/shots/:shotId', async (req, res) => {
   );
   if (!playlist) return res.status(404).json({ error: 'Playlist not found' });
   res.json(playlist);
+});
+
+// Directory routes
+app.get('/api/directories', async (req, res) => {
+  const dirs = await Directory.find();
+  res.json(dirs.map(d => d.path));
+});
+
+app.post('/api/directories', async (req, res) => {
+  const { path } = req.body;
+  if (!path) return res.status(400).json({ error: 'Path required' });
+  try {
+    const dir = new Directory({ path });
+    await dir.save();
+    res.json(dir);
+  } catch (e) {
+    if (e.code === 11000) return res.status(409).json({ error: 'Directory already exists' });
+    res.status(500).json({ error: 'Failed to save directory' });
+  }
 });
 
 const PORT = 3001;


### PR DESCRIPTION
## Summary
- add Mongoose Directory model and endpoints for listing and saving directories
- store selected directory on the client via new API helpers

## Testing
- `cd server && npm test` (fails: Error: no test specified)
- `cd j9 && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6890523c02c08326a17402921a0e619d